### PR TITLE
Update docs, {nasapower} returns NA not -99 or -999

### DIFF
--- a/R/get_power_apsim_met.R
+++ b/R/get_power_apsim_met.R
@@ -20,9 +20,6 @@
 #' ## Note that missing data is coded as -99
 #' summary(pwr)
 #' ## Check for reasonable ranges 
-#' check_apsim_met(pwr)
-#' ## replace -99 with NA
-#' pwr$radn <- ifelse(pwr$radn == -99, NA, pwr$radn)
 #' ## Impute using linear interpolation
 #' pwr.imptd <- impute_apsim_met(pwr, verbose = TRUE)
 #' summary(pwr.imptd)


### PR DESCRIPTION
Unless I've missed something somewhere in the {nasapower} package, any missing values should be `NA`, not a numeric value by default. The relevant section where this replacement occurs is here: https://github.com/ropensci/nasapower/blob/852606ebab8aeb85cdded3b5d2c836f979a659cc/R/internal_functions.R#L512

If you're aware of an instance where this is not true, could you let me know so I can fix it?