### PR TITLE
Update get_power_apsim_met.R to work with latest version of nasapower

### DIFF
--- a/R/get_power_apsim_met.R
+++ b/R/get_power_apsim_met.R
@@ -43,17 +43,17 @@ get_power_apsim_met <- function(lonlat, dates, wrt.dir = ".", filename = NULL){
                               pars = c("T2M_MAX",
                               "T2M_MIN",
                               "ALLSKY_SFC_SW_DWN",
-                              "PRECTOT",
+                              "PRECTOTCORR",
                               "RH2M",
                               "WS2M"),
                               dates = dates,
                               lonlat = lonlat,
-                              temporal_average = "DAILY")
+                              temporal_api = "DAILY")
   
   pwr <- subset(as.data.frame(pwr), select = c("YEAR", "DOY",
                                                "ALLSKY_SFC_SW_DWN",
                                                "T2M_MAX", "T2M_MIN",
-                                               "PRECTOT", "RH2M", "WS2M"))
+                                               "PRECTOTCORR", "RH2M", "WS2M"))
   
   names(pwr) <- c("year", "day", "radn", "maxt", "mint", "rain", "rh", "wind_speed")
   units <- c("()", "()", "(MJ/m2/day)", "(oC)", "(oC)", "(mm)", "(%)", "(m/s)")


### PR DESCRIPTION
This should allow this function to work with the new version of _nasapower_ that I'm planning to release shortly.

The POWER team have made changes to the API that necessitated changes to the parameters, "PRECTOT" is now "PRECTOTCORR" in the API requests.

Also I updated the "temporal_average" to reflect the terminology used by the POWER team to be "temporal_api".