### PR TITLE
:zap: Command run added for apsim in Linux

### DIFF
--- a/R/apsimx.R
+++ b/R/apsimx.R
@@ -70,7 +70,7 @@ apsimx <- function(file = "", src.dir = ".",
       run.strng <- paste(mono, ada, file.name.path) 
     }
     if(isFALSE(dotnet.flag) && isFALSE(mono.flag)){
-      run.strng <- paste(ada, file.name.path) 
+      run.strng <- paste(ada, "run", file.name.path) 
     }
     ## Run APSIM-X on the command line
     if(!missing(xargs)) run.strng <- paste(run.strng, xargs$xargs.string)


### PR DESCRIPTION
### Bug description
I am using apsimx package in a Linux Mint environment. I was able to reproduce the same error by installing apsim in 2 different ways. I installed Apsim both by building from source code with dotnet and by downloading and install the .deb from the apsim website. In both cases, two files were generated in the apsim folder. (1) The **apsim** file which is the executable and need to be run using **apsim run <simulation_name>** and (2) the **ApsimNG** file which is the executable to the interface. I used the function apsimx_options() to set the exe.path, but I am not able to run the apsim() function because if I set the **ApsimNG** as executable, it opens the interface with the simulation, and if I set the **apsim** as executable, the string *run* is missing in the command.
I used the command **dpkg --listfiles apsim** to check the path where apsim was installed. In my case it is in the */usr/local/lib/apsim/2023.7.7283.0/bin/* folder where the files **apsim** and **ApsimNG** are located.

### Suggestion
The apsim.R code should add the **run** string between the ada and the simulation name, or create a new condition. When forking and implementing this, the function apsim() from R package ran perfectly.

```
if(isFALSE(dotnet.flag) && isFALSE(mono.flag)){
  run.strng <- paste(ada, "run", file.name.path) 
}
```

This PR solves the Issue #128