### PR TITLE
L.124 bug, output from strsplit is not numeric

### DIFF
--- a/R/apsimx_soil_profile.R
+++ b/R/apsimx_soil_profile.R
@@ -121,7 +121,7 @@ apsimx_soil_profile <-  function(nlayers = 10,
     Thickness <- numeric(nlayers)
     for(i in 1:length(Depth)){
       tmp <- strsplit(Depth[i],"-")[[1]]
-      Thickness[i] <- (tmp[2] - tmp[1]) * 10
+      Thickness[i] <- (as.numeric(tmp[2]) - as.numeric(tmp[1])) * 10
     }
   }
   


### PR DESCRIPTION
In R, 
When trying to replace the depth argument:

```
ia_profile<-apsimx_soil_profile(
+   nlayers = 9,
+   Depth=c(c(0,100),c(100,200),c(200,300),c(300,400),c(400,500),c(500, 600), c(600,700),c(700,800),c(800,900)))
Error in strsplit(Depth[i], "-") : non-character argument

```

And then:
```
> ia_profile<-apsimx_soil_profile(
+   nlayers = 9,
+   Depth=c("0-100","100-200","200-300","300-400","400-500","500-600", "600-700","700-800","800-900"))
Error in tmp[2] - tmp[1] : non-numeric argument to binary operator

```
Adding `as.numeric` on L.124 solved this problem.



Thanks for the function.